### PR TITLE
replace default regexp in tokenizer on more universal

### DIFF
--- a/measures/pairwise/comparisons.go
+++ b/measures/pairwise/comparisons.go
@@ -107,3 +107,8 @@ func ManhattenDistance(a, b mat.Vector) float64 {
 	v.SubVec(a, b)
 	return mat.Norm(&v, 1)
 }
+
+// DotProductSimilarity calculates the dot product of 2 vectors
+func DotProductSimilarity(a, b mat.Vector) float64 {
+	return sparse.Dot(a, b)
+}

--- a/measures/pairwise/comparisons.go
+++ b/measures/pairwise/comparisons.go
@@ -108,7 +108,11 @@ func ManhattenDistance(a, b mat.Vector) float64 {
 	return mat.Norm(&v, 1)
 }
 
-// DotProductSimilarity calculates the dot product of 2 vectors
-func DotProductSimilarity(a, b mat.Vector) float64 {
-	return sparse.Dot(a, b)
+// VectorLenSimilarity calculates the len of ab vectors
+func VectorLenSimilarity(a, b mat.Vector) float64 {
+	dotProduct := sparse.Dot(a, b)
+	if dotProduct == 0 {
+		return math.NaN()
+	}
+	return math.Sqrt(dotProduct)
 }

--- a/vectorisers.go
+++ b/vectorisers.go
@@ -62,6 +62,7 @@ type RegExpTokeniser struct {
 // NewTokeniser returns a new, default Tokeniser implementation.
 // stopWords is a potentially empty string slice
 // that contains the words that should be removed from the corpus
+// default regExpTokeniser will split words by whitespace/tabs: "\t\n\f\r "
 func NewTokeniser(stopWords ...string) Tokeniser {
 	var stop map[string]bool
 
@@ -70,7 +71,7 @@ func NewTokeniser(stopWords ...string) Tokeniser {
 		stop[word] = true
 	}
 	return &RegExpTokeniser{
-		RegExp:    regexp.MustCompile("[\\p{L}]+"),
+		RegExp:    regexp.MustCompile("[\\S]+"),
 		StopWords: stop,
 	}
 }


### PR DESCRIPTION
old regexp - "[\\p{L}]+" convert documents like  "os24120z R2D2" to ["os","z","R","D"]
replaced with \S - not whitespace [^\t\n\f\r ]